### PR TITLE
fix undefined appearing for results without aliases

### DIFF
--- a/src/search/searchresults.ts
+++ b/src/search/searchresults.ts
@@ -104,7 +104,10 @@ export class SearchResults extends EventEmitter2 {
 
       switch (overlay.overlayType) {
         case 'poi':
-          listItem.textContent = `${overlay.name} (${overlay.aliases?.join(', ')})`;
+          listItem.textContent = overlay.name;
+          if (overlay.aliases) {
+            listItem.textContent += ` (${overlay.aliases.join(', ')})`;
+          }
           break;
 
         case 'aoi':


### PR DESCRIPTION
Prior to this change:
![image](https://github.com/user-attachments/assets/d9ddae1c-4505-4ce6-9ce1-d8dc70519a43)