### PR TITLE
Clickable wiki links fix

### DIFF
--- a/src/data_sources/overlays.ts
+++ b/src/data_sources/overlays.ts
@@ -119,6 +119,7 @@ function createOverlayPopup({ name, aliases, wiki }: Pick<PointOfInterest, 'name
   wikiLink.href = wiki;
   wikiLink.target = '_blank';
   wikiLink.textContent = 'Wiki';
+  wikiLink.classList.add('wikiLink');
   popup.appendChild(wikiLink);
 
   return popup;

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,9 +142,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Dirty fix for Wiki links not working with left mouse button
   document.addEventListener('click', event => {
-    if (event.target instanceof HTMLAnchorElement && event.target.href) {
+    const target = event.target;
+    if (target instanceof HTMLAnchorElement && target.href && target.classList.contains('wikiLink')) {
       event.preventDefault();
-      window.open(event.target.href, '_blank');
+      window.open(target.href, '_blank');
     }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,4 +139,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   //     console.log("not checked");
   //   }
   // });
+
+  // Dirty fix for Wiki links not working with left mouse button
+  document.addEventListener('click', event => {
+    if (event.target instanceof HTMLAnchorElement && event.target.href) {
+      event.preventDefault();
+      window.open(event.target.href, '_blank');
+    }
+  });
 });


### PR DESCRIPTION
FIX #51 

After some investigation I could not find the culprit for the wiki links not being clickable.

To remedy the issue, I added an click event listener to trigger the link via JavaScript instead.
The listener makes sure the target is a wiki-link HTMLAnchorElement to prevent the event from firing on any other links in the application.

I have tested this implementation with at least 10 link of each section [Structures, Bosses, Items, Orbs].