### PR TITLE
Fix biome overlay styling by changing child selector from div to span

### DIFF
--- a/public/css/overlay-styles.css
+++ b/public/css/overlay-styles.css
@@ -32,7 +32,7 @@
   border: 0.15em solid;
   border-radius: 0.5em;
 
-  & > div {
+  & > span {
     height: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This has been a thing since (presumably) 979d67f0dfb7543d03128817830e807420b03e6f - an OSD update caused a CSS selector to stop selecting a certain element in each biome overlay.
Here's what the overlays currently look like:
<img width="671" height="358" alt="current" src="https://github.com/user-attachments/assets/5830920c-8257-46ea-a787-f937e15cb158" />

And here's what they look like after adjusting one of the selectors in `public/css/overlay-styles.css`:
<img width="734" height="403" alt="new" src="https://github.com/user-attachments/assets/2de2e90a-e4dc-4965-9238-a19c45d9fa6f" />

Otherwise, if the new styling is not desired, the changed rule and its nested rule can (probably) be safely removed.
